### PR TITLE
YDA-6892: add Matomo visit counter parameter

### DIFF
--- a/docker/images/yoda_irods_icat/rules_uu.cfg
+++ b/docker/images/yoda_irods_icat/rules_uu.cfg
@@ -101,5 +101,6 @@ measure_coverage                = 'false'
 pregenerated_data_dir           = '/var/lib/irods/yoda-pregenerated-data'
 
 matomo_tracking_enabled        = 'false'
+matomo_counter_enabled         = 'false'
 matomo_server_fqdn             = ''
 matomo_site_id                 = '1'

--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -474,11 +474,13 @@ landingpage_theme | Name of landingpage theme
 ### Web statistics configuration
 
 The web statistics parameters are used during publication endpoint updates (more specifically, during landing page
-updates). So changes in these parameters only take effect after updating publication endpoints.
+updates). So changes in these parameters only take effect after updating publication endpoints. See also
+[the Matomo integration documentation](../design/other/matomo-integration.md).
 
 Variable                     | Description
 -----------------------------|--------------------------------
 yoda_matomo_tracking_enabled | Enable collection of web statistics for landing pages using [Matomo](https://matomo.org). This requires a separate Matomo environment. By default, collection of web statistics is disabled.
+yoda_matomo_counter_enabled  | Enable visit counters on landing pages using [Matomo](https://matomo.org). This requires a separate Matomo environment. By default, visit counters are disabled. If this is enabled, you probably want to enable `yoda_matomo_tracking_enabled` as well, otherwise no new page visits will be displayed on the counters.
 yoda_matomo_server_fqdn      | Fully-qualified domain name of Matomo web statistics server (for collection of web statistics)
 yoda_matomo_site_id          | Site ID of the landing page domain on the Matomo server. The Site ID is assigned when a website is configured in Matomo. The default site ID is "1".
 

--- a/docs/design/other/index.md
+++ b/docs/design/other/index.md
@@ -6,5 +6,6 @@ has_children: true
 ---
 # Other
 
+* [Matomo integration](matomo-integration.md)
 * [Redis key-value store](redis-data-store.md)
 * [Yoda and the iRODS Python Rule Engine Plugin](python-plugin.md)

--- a/docs/design/other/matomo-integration.md
+++ b/docs/design/other/matomo-integration.md
@@ -1,0 +1,35 @@
+---
+grand_parent: Software design
+parent: Other
+---
+# Matomo integration
+
+Yoda supports tracking web statistics for visits to data package landing
+pages using [Matomo](https://matomo.org), an open source web analytics application.
+
+Yoda has two Matomo-related configuration options:
+- Tracking using Matomo (Ansible parameter: `yoda_matomo_tracking_enabled`): tracks
+  visits to landing pages. By itself, tracking visits does not expose any web analytics
+  data to Yoda users. Only Matomo users can see web analytics information.
+- Visit counter (Ansible parameter: `yoda_matomo_counter_enabled`): when this feature is
+  enabled, a visit counter will be shown to visitors on all Yoda landing pages.
+
+See the [Yoda configuration guide](../../administration/configuring-yoda.md) for further
+information about configuration parameters.
+
+After changing these configuration options, a publication endpoint update is needed
+to effectuate the changes:
+
+```
+irule -r irods_rule_engine_plugin-irods_rule_language-instance -F /etc/irods/yoda-ruleset/tools/update-publications.r
+```
+
+Matomo itself is not part of Yoda, but an associated
+[Ansible playbook](https://github.com/utrechtUniversity/matomo-ansible) is provided
+to deploy a Matomo environment that can be used in combination with Yoda. The visit counter
+feature requires Matomo to have the [Page View Counter Plugin](https://github.com/UtrechtUniversity/matomo-plugin-pageviewcounter)
+installed, and the plugin needs to be configured using the Matomo web interface to make visit
+data of the landing page site publicly available by setting the "Allowed Site IDs" plugin parameter.
+Furthermore, it is necessary to add the landing page domain to the list of Cross-Origin Resource Sharing (CORS) domains
+in the general settings of Matomo, so that browsers permit the front-end page view counter code to access
+the page view counter plugin API.

--- a/docs/release-notes/release-2.1.md
+++ b/docs/release-notes/release-2.1.md
@@ -21,7 +21,7 @@ Released: TBA
 ### Changes affecting technical administrators
 - **SRAM integration**: improved support for external users with separate [OIDC configuration](../administration/configuring-yoda.md)
 - **Copy to research**: improved retry logic and configurable multithreading parameter (vault_copy_multithread_enabled)
-- **Web statistics collection for landing pages**: added functionality to collect web statistics for landing pages using [Matomo](https://matomo.org)
+- **Web statistics collection for landing pages**: added functionality to optionally collect web statistics for landing pages using [Matomo](https://matomo.org) and to show visit count information to landing page visitors. See [the Matomo integration documentation](../design/other/matomo-integration.md) for details.
 
 ### Other changes
 - iRODS: upgrade to v5.0.2

--- a/roles/yoda_landingpages/files/uu/css/uu.css
+++ b/roles/yoda_landingpages/files/uu/css/uu.css
@@ -285,6 +285,63 @@ header .header-title h1 {
     padding: 0;
 }
 
+.statistics {
+    margin-top: 75px;
+    padding-left: 5%;
+    padding-right: 5%;
+    padding-top: 4%;
+    background: #ffcd00;
+}
+.statistics h2 {
+    font-family: 'Merriweather', serif;
+    font-weight: 700;
+    font-style: normal;
+    text-transform: uppercase;
+    font-size: 32;
+}
+
+.statistics .list .group {
+    padding-bottom: 60px;
+}
+.statistics .list .group:last-child {
+    padding-bottom: 20px;
+}
+.statistics .list .group .row:first-child {
+    border-top: 2px solid #797979;
+}
+.statistics .list label {
+    font-family: 'Merriweather', serif;
+    font-weight: 200;
+    font-style: normal;
+    font-size: 18px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    line-height: 1;
+    margin: 0;
+}
+.statistics .list span {
+    width: 100%;
+    display: block;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    line-height: 1;
+    font-family: 'Merriweather', serif;
+    font-weight: 700;
+    font-style: normal;
+    font-size: 18px;
+}
+.statistics .list span a {
+    color: #333333;
+    text-decoration: underline;
+}
+.statistics .list .group .row {
+    border-bottom: 1px solid #797979;
+    margin: 0;
+}
+.statistics .list .group .row div {
+    padding: 0;
+}
+
 .questions {
     margin-top: 60px;
 }

--- a/roles/yoda_landingpages/files/vu/css/vu.css
+++ b/roles/yoda_landingpages/files/vu/css/vu.css
@@ -286,6 +286,64 @@ header .header-title h1 {
     padding: 0;
 }
 
+.statistics {
+    margin-top: 75px;
+    padding-left: 5%;
+    padding-right: 5%;
+    padding-top: 4%;
+    background: #0077b3;
+    color: #ffffff;
+}
+.statistics h2 {
+    font-family: 'Merriweather', serif;
+    font-weight: 700;
+    font-style: normal;
+    text-transform: uppercase;
+    font-size: 32;
+}
+
+.statistics .list .group {
+    padding-bottom: 60px;
+}
+.statistics .list .group:last-child {
+    padding-bottom: 20px;
+}
+.statistics .list .group .row:first-child {
+    border-top: 2px solid #d3d3d3;
+}
+.statistics .list label {
+    font-family: 'Merriweather', serif;
+    font-weight: 200;
+    font-style: normal;
+    font-size: 18px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    line-height: 1;
+    margin: 0;
+}
+.statistics .list span {
+    width: 100%;
+    display: block;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    line-height: 1;
+    font-family: 'Merriweather', serif;
+    font-weight: 700;
+    font-style: normal;
+    font-size: 18px;
+}
+.statistics .list span a {
+    color: #ffffff;
+    text-decoration: underline;
+}
+.statistics .list .group .row {
+    border-bottom: 1px solid #d3d3d3;
+    margin: 0;
+}
+.statistics .list .group .row div {
+    padding: 0;
+}
+
 .questions {
     margin-top: 60px;
 }

--- a/roles/yoda_landingpages/files/wur/css/wur.css
+++ b/roles/yoda_landingpages/files/wur/css/wur.css
@@ -286,6 +286,64 @@ header .header-title h1 {
     padding: 0;
 }
 
+.statistics {
+    margin-top: 75px;
+    padding-left: 5%;
+    padding-right: 5%;
+    padding-top: 4%;
+    background: #0E8542;
+    color: #FFFFFF;
+}
+.statistics h2 {
+    font-family: 'Merriweather', serif;
+    font-weight: 700;
+    font-style: normal;
+    text-transform: uppercase;
+    font-size: 32;
+}
+
+.statistics .list .group {
+    padding-bottom: 60px;
+}
+.statistics .list .group:last-child {
+    padding-bottom: 20px;
+}
+.statistics .list .group .row:first-child {
+    border-top: 2px solid #797979;
+}
+.statistics .list label {
+    font-family: 'Merriweather', serif;
+    font-weight: 200;
+    font-style: normal;
+    font-size: 18px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    line-height: 1;
+    margin: 0;
+}
+.statistics .list span {
+    width: 100%;
+    display: block;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    line-height: 1;
+    font-family: 'Merriweather', serif;
+    font-weight: 700;
+    font-style: normal;
+    font-size: 18px;
+}
+.statistics .list span a {
+    color: #FFFFFF;
+    text-decoration: underline;
+}
+.statistics .list .group .row {
+    border-bottom: 1px solid #797979;
+    margin: 0;
+}
+.statistics .list .group .row div {
+    padding: 0;
+}
+
 .questions {
     margin-top: 60px;
 }

--- a/roles/yoda_rulesets/defaults/main.yml
+++ b/roles/yoda_rulesets/defaults/main.yml
@@ -262,5 +262,6 @@ yoda_rulesets_pregen_data_dir: /var/lib/irods/yoda-pregenerated-data
 
 # Parameters for Matomo web statistics collection on landing pages
 yoda_matomo_tracking_enabled: false
+yoda_matomo_counter_enabled: false
 yoda_matomo_server_fqdn: www.matomo.test
 yoda_matomo_site_id: 1

--- a/roles/yoda_rulesets/templates/rules_uu.cfg.j2
+++ b/roles/yoda_rulesets/templates/rules_uu.cfg.j2
@@ -122,5 +122,6 @@ notifications_enabled          = '{{ ["false", "true"][send_notifications|int] }
 pregenerated_data_dir          = '{{ yoda_rulesets_pregen_data_dir }}'
 
 matomo_tracking_enabled        = '{{ ["false", "true"][yoda_matomo_tracking_enabled|int] }}'
+matomo_counter_enabled         = '{{ ["false", "true"][yoda_matomo_counter_enabled|int] }}'
 matomo_server_fqdn             = '{{ yoda_matomo_server_fqdn }}'
 matomo_site_id                 = '{{ yoda_matomo_site_id }}'


### PR DESCRIPTION
Add Ansible and ruleset parameter for enabling landing page visit counters using Matomo.