### PR TITLE
YDA-6848: Switch to maintained oaipmh module

### DIFF
--- a/docker/images/yoda_public/Dockerfile
+++ b/docker/images/yoda_public/Dockerfile
@@ -59,12 +59,7 @@ RUN /var/www/moai/yoda-moai/venv/bin/pip3 install pysqlite3==0.5.0
 
 ## Install MOAI itself
 ENV C_INCLUDE_PATH /usr/include/python3.12
-RUN /var/www/moai/yoda-moai/venv/bin/pip3 install wheel==0.46.3 && \
-    /var/www/moai/yoda-moai/venv/bin/pip3 install setuptools==81.0.0 && \
-    /var/www/moai/yoda-moai/venv/bin/pip3 install lxml==6.0.2 && \
-    /var/www/moai/yoda-moai/venv/bin/pip3 install six==1.17.0 && \
-    /var/www/moai/yoda-moai/venv/bin/pip3 install --no-build-isolation "pyoai @ git+https://github.com/infrae/pyoai.git@2.5.1" && \
-    /var/www/moai/yoda-moai/venv/bin/pip3 install -e /var/www/moai/yoda-moai
+RUN /var/www/moai/yoda-moai/venv/bin/pip3 install -e /var/www/moai/yoda-moai
 
 ## Configure and initialize MOAI
 COPY moai-settings.ini /var/www/moai/settings.ini

--- a/roles/yoda_moai/handlers/main.yml
+++ b/roles/yoda_moai/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# copyright Utrecht University
+
+- name: Restart Apache webserver
+  ansible.builtin.service:
+    name: "{{ apache_service_name }}"
+    state: restarted

--- a/roles/yoda_moai/tasks/main.yml
+++ b/roles/yoda_moai/tasks/main.yml
@@ -65,31 +65,15 @@
     executable: /var/www/moai/yoda-moai/venv/bin/pip3
 
 
-# We're installing pyoai dependencies manually, because we need to
-# disable build isolation (see below).
-- name: Manually install dependencies of pyoai
+- name: Ensure that legacy pyoai version is no longer installed
   become_user: '{{ yoda_moai_user }}'
   become: true
   ansible.builtin.pip:
-    name:
-      - wheel==0.46.3
-      - setuptools==81.0.0
-      - lxml==6.0.2
-      - six==1.17.0
+    name: pyoai
+    state: absent
+    extra_args: "-y"
     executable: /var/www/moai/yoda-moai/venv/bin/pip3
-
-
-# Build isolation is disabled in order to be able to work around
-# pyoai still depending on pkg_resources, which needs an older
-# setuptools version (see ticket YDA-6847)
-- name: Manually install pyoai dependency
-  become_user: '{{ yoda_moai_user }}'
-  become: true
-  ansible.builtin.pip:
-    name:
-      - "pyoai @ git+https://github.com/infrae/pyoai.git@2.5.1"
-    extra_args: --no-build-isolation
-    executable: /var/www/moai/yoda-moai/venv/bin/pip3
+  notify: Restart Apache webserver
 
 
 # We use the PySqlite3 dialect to avoid compatibility issues between SQLAlchemy
@@ -114,7 +98,10 @@
   ansible.builtin.pip:
     name: '{{ yoda_moai_home }}/yoda-moai'
     virtualenv: '{{ yoda_moai_home }}/yoda-moai/venv'
-    extra_args: "-e"
+    # We need the force parameter for the transition from the pyoai library (in Yoda
+    # 2.0.x) to the oaipmh library (Yoda 2.1.x). Can be removed when this is no longer
+    # relevant.
+    extra_args: "--force"
   environment:
     C_INCLUDE_PATH: "{{ yoda_moai_python3_include_path }}"
   changed_when: false

--- a/roles/yoda_moai/vars/Debian.yml
+++ b/roles/yoda_moai/vars/Debian.yml
@@ -4,6 +4,8 @@
 openssl_private_dir: '/etc/ssl/private/'
 openssl_certs_dir: '/etc/ssl/certs'
 
+apache_service_name: apache2
+
 yoda_moai_python3_path: /usr/bin/python3
 yoda_moai_python3_include_path: /usr/include/python3.12
 

--- a/roles/yoda_moai/vars/RedHat.yml
+++ b/roles/yoda_moai/vars/RedHat.yml
@@ -4,6 +4,8 @@
 openssl_private_dir: '/etc/ssl/private/'
 openssl_certs_dir: '/etc/ssl/certs'
 
+apache_service_name: httpd
+
 yoda_moai_python3_path: /usr/bin/python3.12
 yoda_moai_python3_include_path: /usr/include/python3.12
 


### PR DESCRIPTION
The infra/pyoai module is no longer maintained. Move to the ETH-CH/oaipmh fork, which has maintenance fixes. This also makes it possible to remove the workaround for the use of pkg_resources