### PR TITLE
Config checks

### DIFF
--- a/docs/administration/configuring-yoda.md
+++ b/docs/administration/configuring-yoda.md
@@ -134,6 +134,7 @@ centos_sclo_rh_repository    | Name of the CentOS SCLO-RH repository
 common_custom_dns_enable     | Set custom DNS servers (default: false, only supported only on Ubuntu)
 common_custom_dns_primary    | Primary custom DNS server (default: Google DNS servers, only supported on Ubuntu)
 common_custom_dns_secondary  | Secondary custom DNS server (default: Google DNS servers, only supported on Ubuntu)
+common_insecure_config_check | Check configuration for insecure settings. 'auto' (the default value) enables the checks if and only if `yoda_environment` is set to a value other than "development". Other valid values are: "enabled" and "disabled".
 
 Note: if one of these variables are different for a host then define them in the corresponding host specific variables file (host_vars).
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -9,3 +9,52 @@ commons_default_umask: "0027"
 common_custom_dns_enable: false
 common_custom_dns_primary: 9.9.9.9
 common_custom_dns_secondary: 149.112.112.112
+
+# Insecure config check can be set to:
+# "disabled"
+# "auto" - meaning it is disabled in development mode but otherwise enabled
+# "enabled"
+common_insecure_config_check: "auto"
+
+yoda_version: development
+yoda_eus_version: "{{ yoda_version }}"
+yoda_portal_version: "{{ yoda_version }}"
+
+# Ruleset configuration.
+yoda_ruleset_version: "{{ yoda_version }}"
+core_rulesets:
+  - name: yoda-ruleset
+    repo: https://github.com/UtrechtUniversity/yoda-ruleset.git
+    ruleset_name: rules-uu
+    version: "{{ yoda_ruleset_version }}"
+    install_scripts: true
+  - name: core
+    ruleset_name: core
+    path: /etc/irods/core.re
+    install_scripts: false
+
+extra_rulesets: []
+
+irods_password: rods                       # iRODS admin password
+irods_database_password: irodsdev
+
+# Data Access Tokens
+enable_tokens: false                    # Enable data access tokens for webDAV and iCommands
+token_database_password: PLACEHOLDER                    # Token database password
+
+# SRAM Configuration
+enable_sram: false                                 # Enable SRAM configuration
+sram_rest_api_url: sram-mock.yoda.test
+
+# External User Service configuration
+eus_api_secret: PLACEHOLDER
+eus_db_password: PLACEHOLDER
+
+# Anubis configuration
+enable_anubis: false                # Enable Anubis
+anubis_redis_password: PLACEHOLDER  # Password for the Redis instance used by Anubis
+
+# This key is an "insecure" private key we offer for use in development instances.
+# If you use this instance for anything other than development, you should create your own key.
+# openssl rand -hex 32
+anubis_ed25519_private_key: 6df19fb7373c1582789d279218147adce2422b80c0fd3389f52d390490e338e9

--- a/roles/common/tasks/config-checks.yml
+++ b/roles/common/tasks/config-checks.yml
@@ -23,3 +23,14 @@
     msg: 'Invalid ruleset name {{ item.name }}'
   with_items: "{{ extra_rulesets + core_rulesets }}"
   when: "'/' in item.name or '..' in item.name"
+
+
+- name: Check insecure config check setting
+  ansible.builtin.fail:
+    msg: 'Invalid insecure configuration check setting'
+  when: common_insecure_config_check not in ['auto', 'disabled', 'enabled']
+
+
+- name: Configuration checks
+  ansible.builtin.import_tasks: insecure-config-checks.yml
+  when: common_insecure_config_check == 'enabled' or (common_insecure_config_check == 'auto' and yoda_environment != 'development')

--- a/roles/common/tasks/config-checks.yml
+++ b/roles/common/tasks/config-checks.yml
@@ -1,0 +1,25 @@
+---
+# copyright Utrecht University
+
+- name: Check for Yoda reporting without client tools
+  ansible.builtin.fail:
+    msg: "Configuration error: enable_yoda_report=true requires enable_yoda_clienttools=true"
+  when:
+    - enable_yoda_report | default(false)
+    - not enable_yoda_clienttools | default(false)
+
+
+# EUS depends on the Yoda portal for theming information. So running mismatched versions
+# can result in unexpected errors.
+- name: Check whether Yoda portal version matches EUS version
+  ansible.builtin.fail: # noqa ignore-errors
+    msg: "Warning: mismatched EUS and portal version can result in EUS theming problems."
+  when: "yoda_portal_version != yoda_eus_version"
+  ignore_errors: true
+
+
+- name: Sanity check ruleset names
+  ansible.builtin.fail:
+    msg: 'Invalid ruleset name {{ item.name }}'
+  with_items: "{{ extra_rulesets + core_rulesets }}"
+  when: "'/' in item.name or '..' in item.name"

--- a/roles/common/tasks/insecure-config-checks.yml
+++ b/roles/common/tasks/insecure-config-checks.yml
@@ -1,0 +1,62 @@
+---
+# copyright Utrecht University
+
+
+- name: Check for default iRODS admin password
+  ansible.builtin.fail:
+    msg: 'Insecure configuration: default iRODS admin password.'
+  when: irods_password == "rods" and (groups.get('icats', []) != [] or
+                                      groups.get('resources', []) != [] )
+
+
+- name: Check for default iRODS database password
+  ansible.builtin.fail:
+    msg: 'Insecure configuration: iRODS database password.'
+  when: irods_database_password == "irodsdev" and groups.get('icats', []) != []
+
+
+- name: Check for EUS enabled with placeholder secret
+  ansible.builtin.fail:
+    msg: 'Insecure configuration: EUS enabled, but EUS secret not set.'
+  when: groups.get('eus', []) != [] and eus_api_secret == "PLACEHOLDER"
+
+
+- name: Check for EUS enabled with placeholder database password
+  ansible.builtin.fail:
+    msg: 'Insecure configuration: EUS enabled, but EUS database password not set.'
+  when: groups.get('eus', []) != [] and eus_db_password == "PLACEHOLDER"
+
+
+- name: Check for data access tokens enabled but database password not set
+  ansible.builtin.fail:
+    msg: 'Insecure configuration: Data access tokens enabled, but database password not set.'
+  when: enable_tokens and token_database_password == "PLACEHOLDER"
+
+
+- name: Check for Anubis enabled but Redis password not set
+  ansible.builtin.fail:
+    msg: 'Insecure configuration: Anubis enabled, but Redis password not set.'
+  when: enable_anubis and anubis_redis_password == "PLACEHOLDER"
+
+
+- name: Check for Anubis with insecure default key
+  ansible.builtin.fail:
+    msg: 'Insecure configuration: Anubis enabled with insecure default key.'
+  when: enable_anubis and anubis_ed25519_private_key == "6df19fb7373c1582789d279218147adce2422b80c0fd3389f52d390490e338e9"
+
+
+- name: Check for SRAM running against mock service
+  ansible.builtin.fail:
+    msg: 'Insecure configuration: SRAM is configured to run against the Mock service.'
+  when: enable_sram and sram_rest_api_url == "sram-mock.yoda.test"
+
+
+- name: Check for SRAM running against Wiremock
+  ansible.builtin.fail:
+    msg: 'Insecure configuration: SRAM is configured to run against WireMock'
+  when: enable_sram and (
+        "https://oauth.wiremockapi.cloud" in (sram_oidc_auth_base_uri | default("")) or
+        "https://oauth.wiremockapi.cloud" in (sram_oidc_token_uri | default("")) or
+        "https://oauth.wiremockapi.cloud" in (sram_oidc_userinfo_uri | default("")) or
+        "https://oauth.wiremockapi.cloud" in (sram_oidc_jwks_uri | default("")) or
+        "https://oauth.wiremockapi.cloud" in (sram_oidc_jwt_issuer | default("")))

--- a/roles/common/tasks/main-tasks.yml
+++ b/roles/common/tasks/main-tasks.yml
@@ -1,6 +1,9 @@
 ---
 # copyright Utrecht University
 
+- name: Configuration checks
+  ansible.builtin.import_tasks: config-checks.yml
+
 - name: Setup hostname
   ansible.builtin.import_tasks: hostname.yml
 

--- a/roles/yoda_external_user_service/tasks/main.yml
+++ b/roles/yoda_external_user_service/tasks/main.yml
@@ -5,15 +5,6 @@
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
 
 
-# EUS depends on the Yoda portal for theming information. So running mismatched versions
-# can result in unexpected errors.
-- name: Check whether Yoda portal version matches EUS version
-  ansible.builtin.fail: # noqa ignore-errors
-    msg: "Warning: mismatched EUS and portal version can result in EUS theming problems."
-  when: "yoda_portal_version != yoda_eus_version"
-  ignore_errors: true
-
-
 - name: Ensure yodadeployment user exists
   ansible.builtin.user:
     name: "{{ yoda_deployment_user }}"

--- a/roles/yoda_report/tasks/main.yml
+++ b/roles/yoda_report/tasks/main.yml
@@ -1,14 +1,6 @@
 ---
 # copyright Utrecht University
 
-- name: Fail if clienttools is not enabled
-  ansible.builtin.fail:
-    msg: "enable_yoda_report=true requires enable_yoda_clienttools=true"
-  when:
-    - enable_yoda_report | default(false)
-    - not enable_yoda_clienttools | default(false)
-
-
 - name: Install yoda reporting private key
   become_user: '{{ irods_service_account }}'
   become: true

--- a/roles/yoda_rulesets/tasks/main.yml
+++ b/roles/yoda_rulesets/tasks/main.yml
@@ -5,13 +5,6 @@
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
 
 
-- name: Sanity check ruleset names
-  ansible.builtin.fail:
-    msg: 'Invalid ruleset name {{ item.name }}'
-  with_items: "{{ extra_rulesets + core_rulesets }}"
-  when: "'/' in item.name or '..' in item.name"
-
-
 - name: Check out rulesets without local patches from Github
   become_user: "{{ irods_service_account }}"
   become: true


### PR DESCRIPTION
    YDA-7032: add insecure config checks to playbook
    
    Add insecure configuration checks to the playbook so that
    users are warned if they try to deploy an insecure configuration.
    
    By default, these checks are disabled on development environments and
    enabled on non-development environments, but technical administrators
    can also manually enable/disable these checks.