### PR TITLE
YDA-7000: adjust archive scripts to allow paths with spaces and quotes

### DIFF
--- a/roles/data_archive/files/data_archive/scripts/daattr
+++ b/roles/data_archive/files/data_archive/scripts/daattr
@@ -1,2 +1,2 @@
 #!/bin/sh
-printf "%q " "$@" | xargs daattr -a state -d ":"
+printf '%s\0' "$@" | xargs -0 daattr -a state -d ":"

--- a/roles/data_archive/files/data_archive/scripts/daget
+++ b/roles/data_archive/files/data_archive/scripts/daget
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo "$@" | xargs daget -a
+printf '%s\0' "$@" | xargs -0 daget -a

--- a/roles/data_archive_mock/files/data_archive/scripts/daattr
+++ b/roles/data_archive_mock/files/data_archive/scripts/daattr
@@ -1,3 +1,3 @@
 #!/bin/sh
 . /var/lib/irods/data-archive-mock/data_archive_venv/bin/activate
-echo "$@" | xargs daattr -a state -d ":"
+printf '%s\0' "$@" | xargs -0 daattr -a state -d ":"

--- a/roles/data_archive_mock/files/data_archive/scripts/daget
+++ b/roles/data_archive_mock/files/data_archive/scripts/daget
@@ -1,3 +1,3 @@
 #!/bin/sh
 . /var/lib/irods/data-archive-mock/data_archive_venv/bin/activate
-echo "$@" | xargs daget -a
+printf '%s\0' "$@" | xargs -0 daget -a


### PR DESCRIPTION
This PR adjust the `daget` and `daattr` scripts for tape archive to allow paths that include spaces and single quotes.