### PR TITLE
YDA-7175: fix metadata schema updates

### DIFF
--- a/roles/yoda_rulesets/tasks/yoda-ruleset.yml
+++ b/roles/yoda_rulesets/tasks/yoda-ruleset.yml
@@ -211,7 +211,7 @@
       delay: 5
       retries: 25
       with_items: "{{ schema_update.results }}"
-      when: not ansible_check_mode
+      when: not ansible_check_mode and item.ansible_job_id is defined
 
 
     - name: Clean up async files for metadata schema checks
@@ -221,7 +221,7 @@
         jid: "{{ item.ansible_job_id }}"
         mode: cleanup
       with_items: "{{ schema_update.results }}"
-      when: not ansible_check_mode
+      when: not ansible_check_mode and item.ansible_job_id is defined
 
 
     - name: Set configuration AVUs for metadata schemas


### PR DESCRIPTION
The playbook previously waited for and cleaned up for updates of all metadata schemas. This resulted in the playbook failing if some metadata schemas were configured to not be installed. This fix ensures that the playbook only waits for and cleans up for metadata schemas that have actually been updated.