### PR TITLE
YDA-7177: fix MOAI subinterpreter issue

### DIFF
--- a/docker/images/yoda_public/yoda-public-vhost.conf
+++ b/docker/images/yoda_public/yoda-public-vhost.conf
@@ -17,6 +17,7 @@
 
     WSGIDaemonProcess moai user=yodadeployment group=yodadeployment threads=5 python-home=/var/www/moai/yoda-moai/venv
     WSGIProcessGroup moai
+    WSGIApplicationGroup %{GLOBAL}
     WSGIScriptAlias /oai /var/www/moai/moai.wsgi
     WSGIScriptReloading On
 

--- a/roles/yoda_public/templates/yoda-public-anubis-vhost.conf.j2
+++ b/roles/yoda_public/templates/yoda-public-anubis-vhost.conf.j2
@@ -95,6 +95,7 @@ Listen {{ yoda_public_port }}
     </Directory>
 
     WSGIDaemonProcess moai user={{ yoda_moai_user }} group={{ yoda_moai_user }} threads=5 python-home={{ yoda_moai_home }}/yoda-moai/venv
+    WSGIApplicationGroup %{GLOBAL}
     WSGIProcessGroup moai
     WSGIScriptAlias /oai {{ yoda_moai_home }}/moai.wsgi
     WSGIScriptReloading On

--- a/roles/yoda_public/templates/yoda-public-vhost.conf.j2
+++ b/roles/yoda_public/templates/yoda-public-vhost.conf.j2
@@ -31,6 +31,7 @@ Listen {{ yoda_public_port }}
     </Directory>
 
     WSGIDaemonProcess moai user={{ yoda_moai_user }} group={{ yoda_moai_user }} threads=5 python-home={{ yoda_moai_home }}/yoda-moai/venv
+    WSGIApplicationGroup %{GLOBAL}
     WSGIProcessGroup moai
     WSGIScriptAlias /oai {{ yoda_moai_home }}/moai.wsgi
     WSGIScriptReloading On


### PR DESCRIPTION
Fix issue where MOAI was unable to start because native code in lxml is not compatible with running on subinterpreters in WSGI.

See also https://modwsgi.readthedocs.io/en/latest/user-guides/application-issues.html#python-simplified-gil-state-api for context.