### PR TITLE
YDA-7090: patch genquery.py to escape single quotes in query conditions

### DIFF
--- a/docker/images/yoda_irods_icat/Dockerfile
+++ b/docker/images/yoda_irods_icat/Dockerfile
@@ -100,6 +100,8 @@ COPY irods.pam /tmp/irods.pam
 COPY oidc.py /tmp/oidc.py
 RUN install -m 0644 /tmp/irods.pam /etc/pam.d/irods && \
     install -m 0644 -o irods -g irods /tmp/oidc.py /var/lib/irods/msiExecCmd_bin/oidc.py
+COPY stage/genquery.py /tmp/genquery.py
+RUN install -m 0644 -o irods -g irods /tmp/genquery.py /etc/irods/genquery.py
 
 # Configure iRODS
 COPY server_config.json /etc/irods/server_config.json

--- a/docker/images/yoda_irods_icat/stage-uploads.sh
+++ b/docker/images/yoda_irods_icat/stage-uploads.sh
@@ -17,3 +17,4 @@ fi
 cp ../../../roles/pam_python/files/Debian/pam_python3.so stage
 cp ../../../roles/irods_completion/files/irods_completion.sh stage
 cp ../../../roles/irods_log/files/irods-log-transform.py stage
+cp ../../../roles/irods_icat/files/genquery.py stage

--- a/roles/irods_icat/files/genquery.py
+++ b/roles/irods_icat/files/genquery.py
@@ -3,6 +3,7 @@ import re
 from collections import OrderedDict
 from enum import Enum
 from irods_errors import END_OF_RESULTSET
+from tstrings import Template
 
 def AUTO_CLOSE_QUERIES(): return True
 
@@ -56,7 +57,7 @@ class Query(object):
 
     :param callback:       iRODS callback
     :param columns:        a list of SELECT column names, or columns as a comma-separated string.
-    :param conditions:     (optional) where clause, as a string
+    :param conditions:     (optional) where clause, as a string or Template
     :param output:         (optional) [default=AS_TUPLE] either AS_DICT/AS_LIST/AS_TUPLE
     :param offset:         (optional) starting row (0-based), can be used for pagination
     :param limit:          (optional) maximum amount of results, can be used for pagination
@@ -115,7 +116,8 @@ class Query(object):
     """
 
     __parameter_names = tuple('columns,conditions,output,offset,limit,case_sensitive,options,parser,order_by'.split(','))
-    __non_whitespace = re.compile('\S+')
+    __non_whitespace = re.compile(r'\S+')
+    _like_pattern = re.compile(r'\bLIKE\s*$', re.IGNORECASE)
 
     def __init__(self,
                  callback,
@@ -140,6 +142,9 @@ class Query(object):
 
         if not isinstance (columns, list):
             raise GenQuery_Columns_Type_Error("'columns' could not be coerced to list type")
+
+        if isinstance(conditions, Template):
+            conditions = self.escape_conditions_params(conditions)
 
         if parser not in [Parser.GENQUERY1, Parser.GENQUERY2]:
             raise ValueError('Invalid value for [parser]. Expected Parser.GENQUERY1 or Parser.GENQUERY2.')
@@ -397,6 +402,37 @@ class Query(object):
             break
         self._close()
         return result
+
+    def escape_conditions_params(self, conditions):
+        """Escape single quotes and LIKE wildcards (% and _) in parameter values that follow LIKE clauses.
+
+        :param conditions: Conditions template alternating between static strings and parameter values
+
+        :returns: Escaped conditions string with all parts joined.
+        """
+        parts = []
+        last_sql = ""
+
+        for item in conditions:
+            if isinstance(item, str):
+                # Static template string.
+                parts.append(item)
+                last_sql = item
+            else:
+                # Template value.
+                value = str(getattr(item, 'value', item))
+
+                # Escape LIKE wildcards if last SQL fragment ends with LIKE.
+                if self._like_pattern.search(last_sql):
+                    value = value.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+
+                # Escape single quotes.
+                value = value.replace("'", "''")
+
+                parts.append(value)
+                last_sql = ""
+
+        return "".join(parts)
 
     def __str__(self):
         projections = ', '.join(self.columns)


### PR DESCRIPTION
This PR repatches the genquery.py script to include a function to escape single quotes in query condition values.