### PR TITLE
YDA-7198: add task to disable unattended upgrades

### DIFF
--- a/roles/common/tasks/disable-unattended-upgrades.yml
+++ b/roles/common/tasks/disable-unattended-upgrades.yml
@@ -1,0 +1,8 @@
+---
+# copyright Utrecht University
+
+- name: Ensure unattended-upgraded service has been stopped and disabled
+  ansible.builtin.service:
+    name: unattended-upgrades
+    state: stopped
+    enabled: false

--- a/roles/common/tasks/main-tasks.yml
+++ b/roles/common/tasks/main-tasks.yml
@@ -34,6 +34,10 @@
   ansible.builtin.import_tasks: basics-debian.yml
   when: ansible_os_family == 'Debian'
 
+- name: Disable unattended upgrades
+  ansible.builtin.import_tasks: disable-unattended-upgrades.yml
+  when: ansible_os_family == 'Debian'
+
 - name: Setup kernel parameters
   ansible.builtin.import_tasks: kernel.yml
 


### PR DESCRIPTION
This is needed for Ubuntu servers so that unattended upgrades doesn't randomly break cronjobs and user connections when restarting services.